### PR TITLE
chore: switch to hiimjasmine00's release geode mod workflow to upload crossplatform geode binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,51 +1,89 @@
-name: Release
+# name: Release
+name: Release Geode Mod
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
-permissions:
-  contents: write
+# permissions:
+#   contents: write
+
+# jobs:
+#   build-windows:
+#     name: Build Windows Release
+#     runs-on: windows-latest
+
+#     steps:
+#       - uses: actions/checkout@v4
+
+#       - name: Build the mod
+#         uses: geode-sdk/build-geode-mod@main
+#         with:
+#           combine: true
+
+#       - name: Upload Windows build
+#         uses: actions/upload-artifact@v4
+#         with:
+#           name: windows-build
+#           path: build/treehousefalcon.auto-download-sounds.geode
+
+#   create-release:
+#     name: Create Release
+#     runs-on: ubuntu-latest
+#     needs: ["build-windows"]
+
+#     steps:
+#       - uses: actions/checkout@v4
+
+#       - name: Download Windows build
+#         uses: actions/download-artifact@v4
+#         with:
+#           name: windows-build
+#           path: release-files
+
+#       - name: Create Release
+#         uses: softprops/action-gh-release@v1
+#         with:
+#           files: release-files/**
+#           draft: false
+#           prerelease: false
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  build-windows:
-    name: Build Windows Release
-    runs-on: windows-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build the mod
-        uses: geode-sdk/build-geode-mod@main
-        with:
-          combine: true
-
-      - name: Upload Windows build
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-build
-          path: build/treehousefalcon.auto-download-sounds.geode
-
-  create-release:
-    name: Create Release
+  release:
+    name: Release mod
     runs-on: ubuntu-latest
-    needs: ["build-windows"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download Windows build
-        uses: actions/download-artifact@v4
+      - uses: hiimjasmine00/release-geode-mod@main
         with:
-          name: windows-build
-          path: release-files
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: release-files/**
+          # The GitHub token to use for the release.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # The path to the mod's directory. Defaults to the current directory.
+          path: ./
+          # Whether or not to replace an existing release. Defaults to false.
+          replace: false
+          # Whether or not to create a draft release. Defaults to false.
           draft: false
+          # Whether or not to create a pre-release. Defaults to false.
           prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish mod
+    runs-on: ubuntu-latest
+    needs: ['release']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hiimjasmine00/release-geode-mod/publish@main
+        with:
+          # The GitHub token to use for the release.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # The path to the mod's directory. Defaults to the current directory.
+          path: ./


### PR DESCRIPTION
noticed that the geode mod binary ultimately accepted to geode index (for 2.2074) was windows-only even though the mod compiles for all platforms.

was unable to make anything of the existing workflow responsible for uploading said geode mod binary, so i commented it out and dropped in https://github.com/hiimjasmine00/release-geode-mod workflow files.

made as a separate pull request to keep things organized.

untested since github doesn't give me the option to run the workflow.

i *did* keep this original bit of syntax though:
```yml
  push:
    tags:
      - "v[0-9]+.[0-9]+.[0-9]+"
```